### PR TITLE
add: useContextを返すカスタムフックを追加

### DIFF
--- a/src/hooks/useTimerContext.ts
+++ b/src/hooks/useTimerContext.ts
@@ -1,0 +1,11 @@
+import { useContext } from "react";
+import { TimerContext } from "../contexts";
+
+/**
+ * Timer contextを使用するための関数
+ * @returns {object} {state, dispatch}
+ */
+export const useTimerContext = () => {
+  const { state, dispatch } = useContext(TimerContext);
+  return { state, dispatch };
+};


### PR DESCRIPTION
コンポーネントごとにuseContextを使用するのは冗長なので、カスタムフックとしてContextを利用可能にする。